### PR TITLE
Fix crashing bug

### DIFF
--- a/legistar/scraper.py
+++ b/legistar/scraper.py
@@ -8,6 +8,7 @@ import mechanize
 from collections import defaultdict
 import slate
 import cStringIO
+import pdfminer
 
 class LegistarScraper (object):
   """
@@ -379,7 +380,11 @@ class LegistarScraper (object):
           if tries_left:
             return self._extractPdfText(pdf_key, tries_left-1)
 
-    doc = slate.PDF(pdf_data)
+    try:
+      doc = slate.PDF(pdf_data)
+    except pdfminer.psparser.PSException:
+      print 'not a PDF or bad PDF, ignoring it'
+      return ''
 
     return '\n'.join(doc)
 


### PR DESCRIPTION
This fixes a crashing bug in the scraper on the rare occasion when the attachment is not a PDF.  

An example with a TIF attachment is here http://oakland.legistar.com/LegislationDetail.aspx?ID=1144399&GUID=E439AA64-1A48-43C7-998F-71CEC1CD2342&Options=ID|Text|&Search=fmc071012
