### PR TITLE
Added test coverage for topic gathering

### DIFF
--- a/tests/test_legistar_scraper.py
+++ b/tests/test_legistar_scraper.py
@@ -197,8 +197,28 @@ def philly_sponsors():
   legislation_details = scraper.expandLegislationSummary(legislation_summary)
   assert_equal(legislation_details[0]["Sponsors"][0], u'Councilmember DiCicco')
 
+@istest
+def chicago_topics():
+  """Tests that scraper works for Chicago for legislation with and without topics"""
+  config = Config(hostname = 'chicago.legistar.com').defaults(DEFAULT_CONFIG)
+  scraper = LegistarScraper(config)
+  legislation_with_topics = {'URL': 'http://chicago.legistar.com/LegislationDetail.aspx?ID=1319481&GUID=40B01792-C9D8-4E8C-BADE-2D27BFC8284D'}
+  legislation_details = scraper.expandLegislationSummary(legislation_with_topics)
+  assert_equal(legislation_details[0]["Indexes"][0], u'PUBLIC WAY USAGE - Awnings')
 
+  legislation_no_topics = {'URL': 'http://chicago.legistar.com/LegislationDetail.aspx?ID=1429779&GUID=118DDF75-D698-4526-BA54-B560BB6CCB04'}
+  legislation_details = scraper.expandLegislationSummary(legislation_no_topics)
+  assert_equal(len(legislation_details[0]["Indexes"]), 0)
 
+@istest
+def philly_topics():
+  """Tests that scraper works for Philly legislation with and without topics"""
+  config = Config(hostname = 'philly.legistar.com').defaults(DEFAULT_CONFIG)
+  scraper = LegistarScraper(config)
+  legislation_with_topics = {'URL': 'http://phila.legistar.com/LegislationDetail.aspx?ID=1433307&GUID=773A9C3F-ABA5-4D6C-B901-A9EEE3B1B8B0'}
+  legislation_details = scraper.expandLegislationSummary(legislation_with_topics)
+  assert_equal(legislation_details[0]["Indexes"][0], u'LIQUOR BY THE DRINK TAX')
 
-
-
+  legislation_no_topics = {'URL': 'http://phila.legistar.com/LegislationDetail.aspx?ID=1426307&GUID=E9EC8885-0DDD-4B64-AB2D-EA0503284268'}
+  legislation_details = scraper.expandLegislationSummary(legislation_no_topics)
+  assert_equal(len(legislation_details[0]["Indexes"]), 0)


### PR DESCRIPTION
Two new tests added to check that scraper works when Topics (Chicago) or Indexes (Philly)
are present and not present for legislation. Despite being called two different things, both sets of topics are held in a <span> with the same ID so the current set up should work and the tests are written to test that.

I guess the  index/topic stuff from @mjumbewu snuck in on the last pull request even though I did that git revert.

Nevertheless - this should complete the topic/index addition to the scraper for Philly and Chicago.
