### PR TITLE
Add topic (index) parsing back in, and update the tests

### DIFF
--- a/legistar/scraper.py
+++ b/legistar/scraper.py
@@ -258,6 +258,11 @@ class LegistarScraper (object):
         sponsors = sponsors_span.text.split(',')
     details[u'Sponsors'] = sponsors
 
+    topics_span = soup.find('span', id='ctl00_ContentPlaceHolder1_lblIndexes2')
+    topics = []
+    if topics_span is not None :
+      topics = [topic.strip() for topic in topics_span.text.split(',')]
+    details[u'Topics'] = topics
 
     related_file_span = soup.find('span', {'id' : 'ctl00_ContentPlaceHolder1_lblRelatedFiles2' })
     if related_file_span is not None:

--- a/tests/test_legistar_scraper.py
+++ b/tests/test_legistar_scraper.py
@@ -206,11 +206,11 @@ def chicago_topics():
   legislation_details = scraper.expandLegislationSummary(legislation_with_topics)
 
   print legislation_details[0]
-  assert_equal(legislation_details[0]["Topic"], u'PUBLIC WAY USAGE - Awnings')
+  assert_equal(legislation_details[0]["Topics"], [u'PUBLIC WAY USAGE - Awnings'])
 
   legislation_no_topics = {'URL': 'http://chicago.legistar.com/LegislationDetail.aspx?ID=1429779&GUID=118DDF75-D698-4526-BA54-B560BB6CCB04'}
   legislation_details = scraper.expandLegislationSummary(legislation_no_topics)
-  assert_not_in("Topic", legislation_details[0])
+  assert_equal(legislation_details[0]["Topics"], [])
 
 @istest
 def philly_topics():
@@ -219,8 +219,8 @@ def philly_topics():
   scraper = LegistarScraper(config)
   legislation_with_topics = {'URL': 'http://phila.legistar.com/LegislationDetail.aspx?ID=1433307&GUID=773A9C3F-ABA5-4D6C-B901-A9EEE3B1B8B0'}
   legislation_details = scraper.expandLegislationSummary(legislation_with_topics)
-  assert_equal(legislation_details[0]["Indexes"], u'LIQUOR BY THE DRINK TAX, SCHOOL TAX AUTHORIZATION')
+  assert_equal(legislation_details[0]["Topics"], [u'LIQUOR BY THE DRINK TAX', u'SCHOOL TAX AUTHORIZATION'])
   legislation_no_topics = {'URL': 'http://phila.legistar.com/LegislationDetail.aspx?ID=1426307&GUID=E9EC8885-0DDD-4B64-AB2D-EA0503284268'}
   legislation_details = scraper.expandLegislationSummary(legislation_no_topics)
-  assert_not_in("Indexes", legislation_details[0])
+  assert_equal(legislation_details[0]["Topics"], [])
 


### PR DESCRIPTION
Legistar pages have an indexes field that is labeled differently depending on the city. This pull request parses the topic/index field, so that consumers of the data have a consistent source of topics.
