### PR TITLE
Handle event keys that are not present

### DIFF
--- a/legistar/scraper.py
+++ b/legistar/scraper.py
@@ -372,14 +372,14 @@ class LegistarScraper (object):
       table = soup.find('table', id='ctl00_ContentPlaceHolder1_gridCalendar_ctl00')
       for event, headers, row in self.parseDataTable(table):
 
-        if type(event['Agenda']) == dict :
+        if 'Agenda' in event and type(event['Agenda']) == dict :
           detail_url = event['Agenda']['url']
           if self.fulltext :
             event['Agenda']['fulltext'] = self._extractPdfText(detail_url)
           else:
             event['Agenda']['fulltext'] = ''
 
-        if type(event['Minutes']) == dict :
+        if 'Minutes' in event and type(event['Minutes']) == dict :
           detail_url = event['Minutes']['url']
           if self.fulltext :
             event['Minutes']['fulltext'] = self._extractPdfText(detail_url)


### PR DESCRIPTION
When scraping Chicago events, I found 'Minutes' was not present. This change allowed script to proceed.

I'm not a pythonista, so perhaps there is a better way.
