### PR TITLE
Handle addresses that do not need host added

### DIFF
--- a/legistar/scraper.py
+++ b/legistar/scraper.py
@@ -173,7 +173,9 @@ class LegistarScraper (object):
           if link is not None:
             address = self._get_link_address(link)
             if address is not None:
-              value = {'label': value, 'url': self.host + address}
+              if 'http' not in address[:4]:
+                address = self.host + address
+              value = {'label': value, 'url': address}
 
           data[key] = value
 


### PR DESCRIPTION
With Chicago data, full URL value is included. Thus adding host breaks the URL.

I have only tested this with Chicago data from https://chicago.legistar.com/Calendar.aspx. I haven't tested with https://phila.legistar.com/Calendar.aspx after the change.
